### PR TITLE
Doom Emacs integration improvements

### DIFF
--- a/psci.el
+++ b/psci.el
@@ -143,20 +143,12 @@ default to the current buffer's directory."
   (let* ((default-directory project-root-folder)
          (psci-program psci/purs-path)
          (extra-sources (psci--get-psc-package-sources!))
-         (buffer (comint-check-proc psci/buffer-name)))
-    ;; pop to the "*psci*" buffer if the process is dead, the
-    ;; buffer is missing or it's got the wrong mode.
-    (pop-to-buffer
-     (if (or buffer (not (derived-mode-p 'psci-mode))
-             (comint-check-proc (current-buffer)))
-         (get-buffer-create (or buffer (psci--process-name psci/buffer-name)))
-       (current-buffer)))
-    ;; create the comint process if there is no buffer.
-    (unless buffer
-      (let ((full-arg-list (append psci/arguments extra-sources)))
-        (apply 'make-comint-in-buffer psci/buffer-name buffer
-               psci-program nil "repl" full-arg-list))
-      (psci-mode))))
+         (full-arg-list (append psci/arguments extra-sources))
+         (buffer (apply 'make-comint-in-buffer psci/buffer-name nil
+                        psci-program nil "repl" full-arg-list)))
+    (with-current-buffer buffer
+      (psci-mode))
+    (pop-to-buffer buffer)))
 
 (defvar psci-mode-map
   (let ((map (nconc (make-sparse-keymap) comint-mode-map)))

--- a/psci.el
+++ b/psci.el
@@ -146,12 +146,15 @@ default to the current buffer's directory."
          (full-arg-list (append psci/arguments extra-sources))
          (buffer (apply 'make-comint-in-buffer psci/buffer-name nil
                         psci-program nil "repl" full-arg-list))
+         (process (get-buffer-process buffer))
          (close-buffer-on-exit (lambda (process _)
                                  (unless (process-live-p process)
                                    (kill-buffer (process-buffer process))))))
     (with-current-buffer buffer
-      (set-process-sentinel (get-buffer-process buffer) close-buffer-on-exit)
-      (psci-mode))
+      (when (eq (process-sentinel process) 'internal-default-process-sentinel)
+        (set-process-sentinel process close-buffer-on-exit))
+      (unless (derived-mode-p 'psci-mode)
+        (psci-mode)))
     (pop-to-buffer buffer)))
 
 (defvar psci-mode-map

--- a/psci.el
+++ b/psci.el
@@ -145,8 +145,12 @@ default to the current buffer's directory."
          (extra-sources (psci--get-psc-package-sources!))
          (full-arg-list (append psci/arguments extra-sources))
          (buffer (apply 'make-comint-in-buffer psci/buffer-name nil
-                        psci-program nil "repl" full-arg-list)))
+                        psci-program nil "repl" full-arg-list))
+         (close-buffer-on-exit (lambda (process _)
+                                 (unless (process-live-p process)
+                                   (kill-buffer (process-buffer process))))))
     (with-current-buffer buffer
+      (set-process-sentinel (get-buffer-process buffer) close-buffer-on-exit)
       (psci-mode))
     (pop-to-buffer buffer)))
 


### PR DESCRIPTION
## Context 

This PR addresses a number of small issues to improve the REPL integration in [doom emacs](https://github.com/hlissner/doom-emacs)

### Repl buffer handling 

> REPL handler %S couldn't open the REPL buffer

> Device 1 is not a termcap terminal device

These errors would appear in a fresh doom emacs install because we're not always returning [a buffer from the interactive `psci` command](https://github.com/purescript-emacs/emacs-psci/blob/23b745b20358d86d48dc96c53a2052a96ce0e6f4/psci.el#L155-L159) and therefore, `+eval--ensure-in-repl-buffer` function [cannot manage the REPL well](https://github.com/hlissner/doom-emacs/blob/fb3fc1970522c911f4d3b89fc39592c3539d5c29/modules/tools/eval/autoload/repl.el#L26-L29). Because we're not holding a reference to the buffer, [it stops midway through](https://github.com/hlissner/doom-emacs/blob/fb3fc1970522c911f4d3b89fc39592c3539d5c29/modules/tools/eval/autoload/repl.el#L31-L34).

### Process handling

`+eval--ensure-in-repl-buffer` uses `buffer-live-p` to check whether the REPL session is active and [re-uses it upon subsequent `SPC o r` call to avoid running a fresh process from scratch](https://github.com/hlissner/doom-emacs/blob/fb3fc1970522c911f4d3b89fc39592c3539d5c29/modules/tools/eval/autoload/repl.el#L24-L25).

However, nowadays, when typing `:q` in the REPL, the process dies but we never close the buffer assigned to the process. Therefore, doom emacs assumes the REPL session is still alive (not true!) and just focuses the existing buffer with dead process instead of starting a completely new process.

This PR addresses this issue by killing the buffer when we detect process exited. 

## Testing

| Before | After |
|:-:|:-:|
| ![before](https://user-images.githubusercontent.com/90652/112235368-ca9bc800-8c3e-11eb-82b4-75add302b0ee.gif) | ![after](https://user-images.githubusercontent.com/90652/112234308-86a7c380-8c3c-11eb-93b9-3f15f877d42f.gif) |

Tested by:

- adding the following in `packages.el` (`SPC f P`) 
```elisp
(package! psci :pin "f5190328ca939c038e7f3f96da2f0fd9ca2054e3" :recipe (:host github :repo "maciejsmolinski/emacs-psci" :branch "doom-emacs"))
```
- running `doom sync -u` from the terminal 
- and finally, restarting emacs





